### PR TITLE
with an issuerId we do not need a jwt, its signed

### DIFF
--- a/src/middlewares/jwtVerify.ts
+++ b/src/middlewares/jwtVerify.ts
@@ -3,6 +3,13 @@ import jwt from "jsonwebtoken";
 import createError from "http-errors";
 
 export function jwtVerify(req: Request, _res: Response, next: NextFunction) {
+  // If request has claimAddress and issuerId, allow it through
+  if (req.body.claimAddress && req.body.issuerId) {
+    (req as ModifiedRequest).isAuthenticated = false; // or true depending on your needs
+    (req as ModifiedRequest).userId = 0;
+    return next();
+  }
+
   try {
     const token = req.headers.authorization?.split(" ")[1];
 


### PR DESCRIPTION
this enables adding claims when signed in with metamask