### PR TITLE
fix: check 'atproto' scope instead of 'com.linkedclaims.authFull' for…

### DIFF
--- a/src/services/atprotoPublisher.ts
+++ b/src/services/atprotoPublisher.ts
@@ -169,13 +169,12 @@ export class AtprotoPublisher {
       if (userDid) {
         const userSession = await AtprotoOAuth.getSession(userDid);
         if (userSession) {
-          // Check if session has the atproto scope (grants repo write access).
-          // Note: we request com.linkedclaims.authFull but Bluesky's auth server
-          // only grants standard scopes. The 'atproto' scope is sufficient for
-          // writing com.linkedclaims.claim records to the user's repo.
+          // Check if session has a scope that grants repo write access.
+          // We accept either com.linkedclaims.authFull (our custom scope, for when
+          // Bluesky supports minimal scopes) or the standard 'atproto' scope.
           const tokenInfo = await userSession.getTokenInfo();
           const scope = tokenInfo.scope || '';
-          if (scope.includes('atproto')) {
+          if (scope.includes('com.linkedclaims.authFull') || scope.includes('atproto')) {
             const { Agent } = await import('@atproto/api');
             const userAgent = new Agent(userSession);
 
@@ -187,7 +186,7 @@ export class AtprotoPublisher {
 
             console.log(`ATProto published claim ${claim.id} to USER repo ${userDid} → ${result.data.uri}`);
           } else {
-            console.log(`ATProto: user ${userDid} session lacks atproto scope (has: ${scope}), falling back to server`);
+            console.log(`ATProto: user ${userDid} session lacks authFull or atproto scope (has: ${scope}), falling back to server`);
           }
         } else {
           console.log(`ATProto: no OAuth session for ${userDid}, falling back to server`);

--- a/src/services/atprotoPublisher.ts
+++ b/src/services/atprotoPublisher.ts
@@ -169,10 +169,13 @@ export class AtprotoPublisher {
       if (userDid) {
         const userSession = await AtprotoOAuth.getSession(userDid);
         if (userSession) {
-          // Check if session has the authFull scope via token info
+          // Check if session has the atproto scope (grants repo write access).
+          // Note: we request com.linkedclaims.authFull but Bluesky's auth server
+          // only grants standard scopes. The 'atproto' scope is sufficient for
+          // writing com.linkedclaims.claim records to the user's repo.
           const tokenInfo = await userSession.getTokenInfo();
           const scope = tokenInfo.scope || '';
-          if (scope.includes('com.linkedclaims.authFull')) {
+          if (scope.includes('atproto')) {
             const { Agent } = await import('@atproto/api');
             const userAgent = new Agent(userSession);
 
@@ -184,7 +187,7 @@ export class AtprotoPublisher {
 
             console.log(`ATProto published claim ${claim.id} to USER repo ${userDid} → ${result.data.uri}`);
           } else {
-            console.log(`ATProto: user ${userDid} session lacks com.linkedclaims.authFull scope (has: ${scope}), falling back to server`);
+            console.log(`ATProto: user ${userDid} session lacks atproto scope (has: ${scope}), falling back to server`);
           }
         } else {
           console.log(`ATProto: no OAuth session for ${userDid}, falling back to server`);


### PR DESCRIPTION
**What was the issue?**
When a Bluesky-authenticated user attempted to publish a claim, the backend fell back to publishing it under the server's DID (`did:plc:xztctnvt5ycnsippd3orwqk7`) instead of the user's personal ATProto repo. 

This occurred because the `atprotoPublisher.ts` service checked the user's session for the custom `com.linkedclaims.authFull` scope. However, Bluesky's authorization server strips out custom scopes and only grants standard scopes like `atproto transition:email`. Because the check failed, the code defaulted to server-signed publishing.

**What changes were made in this PR?**
I updated the condition in `src/services/atprotoPublisher.ts` to check for the standard `atproto` scope instead. The `atproto` scope grants the application full write access to the user's repo (including custom collections like `com.linkedclaims.claim`). 

This change ensures that claims created by authenticated users are properly signed and written to their own DIDs.

**How was it tested?**
- Verified the build succeeds with `npm run build`.
- The fix correctly addresses the scope mismatch identified by querying the Dev Postgres database's `atproto_oauth_session` table.

## Description

Please provide a brief summary of the changes in this PR.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Test case
- [ ] Documentation update
- [ ] Other (please describe)

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works (optional)
- [ ] I have added necessary documentation (if applicable)

## 4- steps to test ?

Please provide a brief summary of the steps required to test the changes in this PR.

## 5- results ?

Please provide a brief summary of the results after testing the changes in this PR.

## 7- screenshots ?

Please provide screenshots of the results after testing the changes in this PR.
