### PR TITLE
docs: document ATProto server-fallback publishing decision and no-ema…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,23 @@ Full mapping: `~/work/3-22-2026-atproto-claim-mapping.md`
 | `source.uri` | `sourceURI` | |
 | `evidence[]` | Image table | one row per item |
 
+### Server-Fallback Publishing (design decision, 2026-04)
+
+When a user doesn't have a Bluesky account (no OAuth session), the server publishes
+their claim to ATProto using the server's own app password. The claim lands in the
+server's repo, not the user's. To make provenance clear, the existing `source` field
+on the ATProto record carries the original author info (sourceURI, howKnown, etc.) —
+no new fields needed.
+
+User emails must NEVER be included in ATProto records. Emails are auth-only data.
+The `source` object, `issuerId`, `statement`, and every other published field must be
+checked to ensure no email address leaks onto a public protocol. If a user's only
+identifier is an email, use their LinkedTrust profile URI or omit the identifier
+entirely — do not publish the email.
+
+See `src/services/atprotoPublisher.ts` — the fallback path is the `!result` branch
+around line 197.
+
 ### Validation Claims
 - A validation claim has `subject` = the URI of the thing being validated
 - The `issuerId` = the person/entity making the validation


### PR DESCRIPTION
…ils rule

Adds design decision to CLAUDE.md so future agents and developers know:
- Server publishes to ATProto on behalf of non-Bluesky users using source field for provenance
- User emails must never appear in ATProto records

## Description

Please provide a brief summary of the changes in this PR.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Test case
- [ ] Documentation update
- [ ] Other (please describe)

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works (optional)
- [ ] I have added necessary documentation (if applicable)

## 4- steps to test ?

Please provide a brief summary of the steps required to test the changes in this PR.

## 5- results ?

Please provide a brief summary of the results after testing the changes in this PR.

## 7- screenshots ?

Please provide screenshots of the results after testing the changes in this PR.
