### PR TITLE
Fix/atproto session restore

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,23 @@ Full mapping: `~/work/3-22-2026-atproto-claim-mapping.md`
 | `source.uri` | `sourceURI` | |
 | `evidence[]` | Image table | one row per item |
 
+### Server-Fallback Publishing (design decision, 2026-04)
+
+When a user doesn't have a Bluesky account (no OAuth session), the server publishes
+their claim to ATProto using the server's own app password. The claim lands in the
+server's repo, not the user's. To make provenance clear, the existing `source` field
+on the ATProto record carries the original author info (sourceURI, howKnown, etc.) —
+no new fields needed.
+
+User emails must NEVER be included in ATProto records. Emails are auth-only data.
+The `source` object, `issuerId`, `statement`, and every other published field must be
+checked to ensure no email address leaks onto a public protocol. If a user's only
+identifier is an email, use their LinkedTrust profile URI or omit the identifier
+entirely — do not publish the email.
+
+See `src/services/atprotoPublisher.ts` — the fallback path is the `!result` branch
+around line 197.
+
 ### Validation Claims
 - A validation claim has `subject` = the URI of the thing being validated
 - The `issuerId` = the person/entity making the validation

--- a/prisma/migrations/20260403000000_add_atproto_oauth_tables/migration.sql
+++ b/prisma/migrations/20260403000000_add_atproto_oauth_tables/migration.sql
@@ -1,0 +1,17 @@
+-- CreateTable
+CREATE TABLE "atproto_oauth_state" (
+    "key" TEXT NOT NULL,
+    "value" JSONB NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "atproto_oauth_state_pkey" PRIMARY KEY ("key")
+);
+
+-- CreateTable
+CREATE TABLE "atproto_oauth_session" (
+    "key" TEXT NOT NULL,
+    "value" JSONB NOT NULL,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "atproto_oauth_session_pkey" PRIMARY KEY ("key")
+);

--- a/src/api/authApi.ts
+++ b/src/api/authApi.ts
@@ -726,6 +726,26 @@ export async function atprotoAuthorize(req: Request, res: Response): Promise<voi
       return;
     }
 
+    // Try to restore an existing OAuth session before redirecting to Bluesky
+    const existing = await AtprotoOAuth.tryRestore(handle);
+    if (existing) {
+      // Session still valid — find the user and issue tokens directly
+      const user = await prisma.user.findFirst({
+        where: { authProviderId: existing.did, authType: 'OAUTH' },
+      });
+
+      if (user) {
+        const { accessToken, refreshToken } = generateTokens(user.id, existing.did);
+        const baseUrl = process.env.BASE_URL || 'https://dev.linkedtrust.us';
+        const redirectUrl = new URL('/login', baseUrl);
+        redirectUrl.searchParams.set('accessToken', accessToken);
+        redirectUrl.searchParams.set('refreshToken', refreshToken);
+
+        res.json({ url: redirectUrl.toString(), restored: true });
+        return;
+      }
+    }
+
     const url = await AtprotoOAuth.authorize(handle, skipEmail);
     res.json({ url });
   } catch (error: any) {

--- a/src/services/atprotoOAuth.ts
+++ b/src/services/atprotoOAuth.ts
@@ -119,6 +119,57 @@ export class AtprotoOAuth {
   }
 
   /**
+   * Try to restore an existing OAuth session for a handle.
+   * Looks up the user's DID in our database and attempts to restore the session.
+   * Returns profile info if a valid session exists, null otherwise.
+   */
+  static async tryRestore(handle: string): Promise<{
+    did: string;
+    handle: string;
+    displayName?: string;
+    avatar?: string;
+    scope: string;
+  } | null> {
+    const cleanHandle = handle.startsWith('@') ? handle.slice(1) : handle;
+
+    // Look up DID from our user table — avoids a network call if we've seen this handle before
+    const user = await prisma.user.findFirst({
+      where: {
+        email: `${cleanHandle}@atproto.local`,
+        authType: 'OAUTH',
+      },
+    });
+
+    const did = user?.authProviderId;
+    if (!did) return null;
+
+    const session = await AtprotoOAuth.getSession(did);
+    if (!session) return null;
+
+    // Session is valid — resolve profile for fresh info
+    const { BskyAgent } = await import('@atproto/api');
+    const agent = new BskyAgent({ service: 'https://public.api.bsky.app' });
+
+    let resolvedHandle = cleanHandle;
+    let displayName: string | undefined;
+    let avatar: string | undefined;
+
+    try {
+      const profile = await agent.getProfile({ actor: did });
+      resolvedHandle = profile.data.handle;
+      displayName = profile.data.displayName;
+      avatar = profile.data.avatar;
+    } catch (err) {
+      console.warn('ATProto OAuth: failed to resolve profile for', did, err);
+    }
+
+    const tokenInfo = await session.getTokenInfo();
+    const grantedScope = tokenInfo.scope || '';
+
+    return { did, handle: resolvedHandle, displayName, avatar, scope: grantedScope };
+  }
+
+  /**
    * Start the OAuth authorization flow.
    * Returns the URL to redirect the user to.
    */


### PR DESCRIPTION
## Description

This PR resolves the issue where users were forced to re-authorize their Bluesky accounts on every login attempt by ensuring OAuth sessions are properly stored and restored.

Database: Added the missing Prisma migration for the atproto_oauth_state and atproto_oauth_session tables. This allows the @atproto/oauth-client-node library to persist session data in Postgres instead of losing it in memory.

Backend Logic (atprotoOAuth.ts): Implemented a new tryRestore(handle) method that looks up the user's DID and checks the database for a valid, existing active session.

API Endpoint (authApi.ts): Updated the atprotoAuthorize endpoint to utilize tryRestore() before generating a new authorization URL. If an active session is found, it issues the JWT tokens directly and returns restored: true, allowing the frontend to bypass the Bluesky consent screen entirely.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Test case
- [ ] Documentation update
- [ ] Other (please describe)

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works (optional)
- [ ] I have added necessary documentation (if applicable)

## 4- steps to test ?

Please provide a brief summary of the steps required to test the changes in this PR.

## 5- results ?

Please provide a brief summary of the results after testing the changes in this PR.

## 7- screenshots ?

Please provide screenshots of the results after testing the changes in this PR.
