### PR TITLE
fix: honor client-supplied effectiveDate on claim creation

### DIFF
--- a/src/api/claims.ts
+++ b/src/api/claims.ts
@@ -580,6 +580,7 @@ export async function createClaim(req: AuthRequest, res: Response): Promise<Resp
       videoUrl, // Video testimonial URL (uploaded separately via /api/video/upload)
       subjectEntityType, // Optional hint for subject entity type (PERSON/ORGANIZATION)
       replace, // If true, delete existing duplicate and create new (claims are immutable)
+      effectiveDate, // When the event being claimed actually occurred (client-supplied)
       ...otherFields // Capture any other fields for debugging
     } = req.body;
     
@@ -630,7 +631,11 @@ export async function createClaim(req: AuthRequest, res: Response): Promise<Resp
       unit: unit || null,
       issuerId: clientIssuerId || userIdUri || null,
       issuerIdType: clientIssuerIdType || 'URL',
-      effectiveDate: new Date()
+      effectiveDate: (() => {
+        if (!effectiveDate) return new Date();
+        const d = new Date(effectiveDate);
+        return isNaN(d.getTime()) ? new Date() : d;
+      })()
     };
     
     console.log('Prepared claim data:', JSON.stringify(claimData, null, 2));


### PR DESCRIPTION
The handler was destructuring req.body without picking up effectiveDate and then hardcoding `new Date()`, so claims with historical dates were always saved as "now" (e.g. a 2021-09-01 entry stored as today). Now reads effectiveDate from the request body and falls back to `new Date()` if missing or unparseable.

## Description

Please provide a brief summary of the changes in this PR.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Test case
- [ ] Documentation update
- [ ] Other (please describe)

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works (optional)
- [ ] I have added necessary documentation (if applicable)

## 4- steps to test ?

Please provide a brief summary of the steps required to test the changes in this PR.

## 5- results ?

Please provide a brief summary of the results after testing the changes in this PR.

## 7- screenshots ?

Please provide screenshots of the results after testing the changes in this PR.
